### PR TITLE
Add AllowSoftdropTap flag

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -55,8 +55,9 @@ void benchmark() {
 
     auto factory = core::Factory::createForSSRPlus();
     constexpr bool Allow180 = true;
-    auto moveGenerator = core::srs::MoveGenerator<Allow180>(factory);
-    auto finder = finder::PerfectClearFinder<Allow180>(factory, moveGenerator);
+    constexpr bool AllowSoftdropTap = true;
+    auto moveGenerator = core::srs::MoveGenerator<Allow180, AllowSoftdropTap>(factory);
+    auto finder = finder::PerfectClearFinder<Allow180, AllowSoftdropTap>(factory, moveGenerator);
 
     {
         auto elapsed = std::chrono::system_clock::now() - start;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -6,7 +6,9 @@
 #include "core/moves.hpp"
 #include "core/field.hpp"
 #include "core/types.hpp"
+#include "finder/concurrent_perfect_clear.hpp"
 #include "finder/perfect_clear.hpp"
+#include "finder/thread_pool.hpp"
 
 template<int N>
 std::array<core::PieceType, N> toPieces(int value) {
@@ -107,9 +109,10 @@ void sample() {
     using namespace std::literals::string_literals;
 
     auto factory = core::Factory::create();
-    // constexpr bool Allow180 = true;
-    auto moveGenerator = core::srs::MoveGenerator(factory);
-    auto finder = finder::PerfectClearFinder(factory, moveGenerator);
+    constexpr bool Allow180 = true;
+    constexpr bool AllowSoftdropTap = false;
+    auto threadPool = finder::ThreadPool(4);
+    auto finder = finder::ConcurrentPerfectClearFinder<Allow180, AllowSoftdropTap>(factory, threadPool);
 
     auto field = core::createField(
             "_XXXXXX___"s +

--- a/src/core/moves.cpp
+++ b/src/core/moves.cpp
@@ -4,9 +4,8 @@
 
 namespace core {
     namespace {
-        constexpr unsigned int kFieldWidthUnsigned = static_cast<unsigned int> (FIELD_WIDTH);
+        constexpr unsigned int kFieldWidthUnsigned = FIELD_WIDTH;
         constexpr int kFieldWidth = FIELD_WIDTH;
-        constexpr int kMaxFieldHeight = MAX_FIELD_HEIGHT;
     }
 
     namespace {
@@ -38,6 +37,28 @@ namespace core {
 
         int boardIndex = index + 4 * rotateType;
         return (visitedBoard[boardIndex] & mask) != 0;
+    }
+
+    void Cache::visitPartially(int x, int y, RotateType rotateType) {
+        assert(0 <= x && x < kFieldWidth);
+        assert(0 <= y && y < kMaxFieldHeight);
+
+        int index = y / 6;
+        uint64_t mask = getXMask(x, y - 6 * index);
+
+        int boardIndex = index + 4 * rotateType;
+        visitedPartiallyBoard[boardIndex] |= mask;
+    }
+
+    bool Cache::isVisitPartially(int x, int y, core::RotateType rotateType) const {
+        assert(0 <= x && x < kFieldWidth);
+        assert(0 <= y && y < kMaxFieldHeight);
+
+        int index = y / 6;
+        uint64_t mask = getXMask(x, y - 6 * index);
+
+        int boardIndex = index + 4 * rotateType;
+        return (visitedPartiallyBoard[boardIndex] & mask) != 0;
     }
 
     void Cache::found(int x, int y, RotateType rotateType) {
@@ -82,24 +103,6 @@ namespace core {
 
         int boardIndex = index + 4 * rotateType;
         return (pushedBoard[boardIndex] & mask) != 0;
-    }
-
-    void Cache::clear() {
-        for (auto &board : visitedBoard) {
-            board = 0;
-        }
-        for (auto &board : foundBoard) {
-            board = 0;
-        }
-        for (auto &board : pushedBoard) {
-            board = 0;
-        }
-    }
-
-    void Cache::resetTrail() {
-        for (auto &board : visitedBoard) {
-            board = 0;
-        }
     }
 
     namespace harddrop {

--- a/src/core/moves.hpp
+++ b/src/core/moves.hpp
@@ -84,7 +84,7 @@ namespace core {
             Left,
         };
 
-        template<bool Allow180 = false>
+        template<bool Allow180 = false, bool AllowSoftdropTap = true>
         class MoveGenerator {
         public:
             explicit MoveGenerator(const Factory &factory) : factory(factory), cache(Cache()), appearY(-1) {
@@ -298,6 +298,13 @@ namespace core {
             ) {
                 auto &field = targetObject.field;
 
+                // When AllowSoftdropTap is false and the piece is in the air, it can only pass through and no operations are allowed
+                if constexpr (!AllowSoftdropTap) {
+                    if (!field.isOnGround(blocks, x, y)) {
+                        return MoveResults::No;
+                    }
+                }
+
                 // When reach by harddrop
                 if (field.canReachOnHarddrop(blocks, x, y)) {
                     return isFirstCall ? MoveResults::Harddrop : MoveResults::Softdrop;
@@ -381,8 +388,8 @@ namespace core {
             Left,
         };
 
-        template<bool Allow180 = false>
-        class Reachable {
+        template<bool Allow180 = false, bool AllowSoftdropTap = true>
+        class  Reachable {
         public:
             explicit Reachable(const Factory &factory) : factory(factory), cache(Cache()), appearY(-1) {
             }
@@ -585,6 +592,13 @@ namespace core {
 
             MoveResults check(const TargetObject &targetObject, const Blocks &blocks, int x, int y, From from) {
                 auto &field = targetObject.field;
+
+                // When AllowSoftdropTap is false and the piece is in the air, it can only pass through and no operations are allowed
+                if constexpr (!AllowSoftdropTap) {
+                    if (!field.isOnGround(blocks, x, y)) {
+                        return MoveResults::No;
+                    }
+                }
 
                 // When reach by harddrop
                 if (field.canReachOnHarddrop(blocks, x, y)) {

--- a/src/core/moves.hpp
+++ b/src/core/moves.hpp
@@ -50,17 +50,48 @@ namespace core {
 
         [[nodiscard]] bool isFound(int x, int y, RotateType rotateType) const;
 
+        void visitPartially(int x, int y, RotateType rotateType);
+
+        [[nodiscard]] bool isVisitPartially(int x, int y, RotateType rotateType) const;
+
         void push(int x, int y, RotateType rotateType);
 
         [[nodiscard]] bool isPushed(int x, int y, RotateType rotateType) const;
 
-        void resetTrail();
+        template<bool AllowSoftdropTap>
+        void clear() {
+            for (auto &board: visitedBoard) {
+                board = 0;
+            }
+            if constexpr (!AllowSoftdropTap) {
+                for (auto &board: visitedPartiallyBoard) {
+                    board = 0;
+                }
+            }
+            for (auto &board: foundBoard) {
+                board = 0;
+            }
+            for (auto &board: pushedBoard) {
+                board = 0;
+            }
+        }
 
-        void clear();
+        template<bool AllowSoftdropTap>
+        void resetTrail() {
+            for (auto &board: visitedBoard) {
+                board = 0;
+            }
+            if constexpr (!AllowSoftdropTap) {
+                for (auto &board: visitedPartiallyBoard) {
+                    board = 0;
+                }
+            }
+        }
 
     private:
         Bitboard visitedBoard[4 * 4];
         Bitboard foundBoard[4 * 4];
+        Bitboard visitedPartiallyBoard[4 * 4];
         Bitboard pushedBoard[4 * 4];
     };
 
@@ -82,6 +113,7 @@ namespace core {
             None,
             Right,
             Left,
+            Down,
         };
 
         template<bool Allow180 = false, bool AllowSoftdropTap = true>
@@ -90,16 +122,16 @@ namespace core {
             explicit MoveGenerator(const Factory &factory) : factory(factory), cache(Cache()), appearY(-1) {
             }
 
-            void search(std::vector<Move> &moves, const Field &field, PieceType pieceType, int validHeight)  {
+            void search(std::vector<Move> &moves, const Field &field, PieceType pieceType, int validHeight) {
                 appearY = validHeight;
 
-                cache.clear();
+                cache.clear<AllowSoftdropTap>();
 
                 auto &piece = factory.get(pieceType);
                 auto target = TargetObject{field, piece};
 
                 for (int rotate = 0; rotate < 4; ++rotate) {
-                    auto rotateType = static_cast<RotateType >(rotate);
+                    auto rotateType = static_cast<RotateType>(rotate);
 
                     auto &blocks = factory.get(pieceType, rotateType);
                     for (int x = -blocks.minX, maxX = FIELD_WIDTH - blocks.maxX; x < maxX; ++x) {
@@ -118,19 +150,20 @@ namespace core {
                                         moves.push_back(Move{newRotate, newX, newY, result == MoveResults::Harddrop});
                                     }
                                 }
-                                cache.resetTrail();
+                                cache.resetTrail<AllowSoftdropTap>();
                             }
                         }
                     }
                 }
             }
 
-            bool canReach(const Field &field, PieceType pieceType, RotateType rotateType, int x, int y, int validHeight) {
+            bool canReach(const Field &field, PieceType pieceType, RotateType rotateType, int x, int y,
+                          int validHeight) {
                 assert(field.canPut(factory.get(pieceType, rotateType), x, y));
 
                 appearY = validHeight;
 
-                cache.clear();
+                cache.clear<AllowSoftdropTap>();
 
                 auto &piece = factory.get(pieceType);
 
@@ -294,41 +327,53 @@ namespace core {
             }
 
             MoveResults check(
-                    const TargetObject &targetObject, const Blocks &blocks, int x, int y, From from, bool isFirstCall
+                const TargetObject &targetObject, const Blocks &blocks, int x, int y, From from, bool isFirstCall
             ) {
                 auto &field = targetObject.field;
 
-                // When AllowSoftdropTap is false and the piece is in the air, it can only pass through and no operations are allowed
+                // When AllowSoftdropTap is false, vertical movement is only allowed down to the ground. (= can be moved with Harddrop).
+                // In other words, upward movement is only allowed during continuous rise from the ground or on the ground.
+                bool allowUp = true;
                 if constexpr (!AllowSoftdropTap) {
-                    if (!field.isOnGround(blocks, x, y)) {
-                        return MoveResults::No;
-                    }
+                    allowUp = from == From::Down || field.isOnGround(blocks, x, y);
                 }
 
                 // When reach by harddrop
-                if (field.canReachOnHarddrop(blocks, x, y)) {
+                if (allowUp && field.canReachOnHarddrop(blocks, x, y)) {
                     return isFirstCall ? MoveResults::Harddrop : MoveResults::Softdrop;
                 }
 
                 // When reach the top
-                if (appearY <= y) {
+                if (allowUp && appearY <= y) {
                     return MoveResults::Softdrop;
                 }
 
                 RotateType rotate = blocks.rotateType;
 
-                // Visited already
-                if (cache.isVisit(x, y, rotate)) {
-                    // Return no when it has been visited and not found because it can be covered by other path
-                    return cache.isFound(x, y, rotate) ? MoveResults::Softdrop : MoveResults::No;
-                }
+                // Since the possible operations differ depending on whether it's in the air or not,
+                // the states are managed separately so that each state can be searched.
+                if (allowUp) {
+                    // Visited already
+                    if (cache.isVisit(x, y, rotate)) {
+                        // Return no when it has been visited and not found because it can be covered by other path
+                        return cache.isFound(x, y, rotate) ? MoveResults::Softdrop : MoveResults::No;
+                    }
 
-                cache.visit(x, y, rotate);
+                    cache.visit(x, y, rotate);
+                } else {
+                    // Visited already
+                    if (cache.isVisitPartially(x, y, rotate)) {
+                        // Return no when it has been visited and not found because it can be covered by other path
+                        return cache.isFound(x, y, rotate) ? MoveResults::Softdrop : MoveResults::No;
+                    }
+
+                    cache.visitPartially(x, y, rotate);
+                }
 
                 // Move up
                 int upY = y + 1;
-                if (upY < appearY && field.canPut(blocks, x, upY)) {
-                    auto result = check(targetObject, blocks, x, upY, From::None, false);
+                if (allowUp && upY < appearY && field.canPut(blocks, x, upY)) {
+                    auto result = check(targetObject, blocks, x, upY, From::Down, false);
                     if (result != MoveResults::No) {
                         return result;
                     }
@@ -386,10 +431,11 @@ namespace core {
             None,
             Right,
             Left,
+            Down,
         };
 
         template<bool Allow180 = false, bool AllowSoftdropTap = true>
-        class  Reachable {
+        class Reachable {
         public:
             explicit Reachable(const Factory &factory) : factory(factory), cache(Cache()), appearY(-1) {
             }
@@ -399,7 +445,7 @@ namespace core {
 
                 appearY = validHeight;
 
-                cache.clear();
+                cache.clear<AllowSoftdropTap>();
 
                 auto &piece = factory.get(pieceType);
 
@@ -593,36 +639,48 @@ namespace core {
             MoveResults check(const TargetObject &targetObject, const Blocks &blocks, int x, int y, From from) {
                 auto &field = targetObject.field;
 
-                // When AllowSoftdropTap is false and the piece is in the air, it can only pass through and no operations are allowed
+                // When AllowSoftdropTap is false, vertical movement is only allowed down to the ground. (= can be moved with Harddrop).
+                // In other words, upward movement is only allowed during continuous rise from the ground or on the ground.
+                bool allowUp = true;
                 if constexpr (!AllowSoftdropTap) {
-                    if (!field.isOnGround(blocks, x, y)) {
-                        return MoveResults::No;
-                    }
+                    allowUp = from == From::Down || field.isOnGround(blocks, x, y);
                 }
 
                 // When reach by harddrop
-                if (field.canReachOnHarddrop(blocks, x, y)) {
+                if (allowUp && field.canReachOnHarddrop(blocks, x, y)) {
                     return MoveResults::Softdrop;
                 }
 
                 // When reach the top
-                if (appearY <= y) {
+                if (allowUp && appearY <= y) {
                     return MoveResults::Softdrop;
                 }
 
                 RotateType rotate = blocks.rotateType;
 
-                // Visited already
-                if (cache.isVisit(x, y, rotate)) {
-                    // Return no when it has been visited and not found because it can be covered by other path
-                    return cache.isFound(x, y, rotate) ? MoveResults::Softdrop : MoveResults::No;
-                }
+                // Since the possible operations differ depending on whether it's in the air or not,
+                // the states are managed separately so that each state can be searched.
+                if (allowUp) {
+                    // Visited already
+                    if (cache.isVisit(x, y, rotate)) {
+                        // Return no when it has been visited and not found because it can be covered by other path
+                        return cache.isFound(x, y, rotate) ? MoveResults::Softdrop : MoveResults::No;
+                    }
 
-                cache.visit(x, y, rotate);
+                    cache.visit(x, y, rotate);
+                } else {
+                    // Visited already
+                    if (cache.isVisitPartially(x, y, rotate)) {
+                        // Return no when it has been visited and not found because it can be covered by other path
+                        return cache.isFound(x, y, rotate) ? MoveResults::Softdrop : MoveResults::No;
+                    }
+
+                    cache.visitPartially(x, y, rotate);
+                }
 
                 // Move up
                 int upY = y + 1;
-                if (upY < appearY && field.canPut(blocks, x, upY)) {
+                if (allowUp && upY < appearY && field.canPut(blocks, x, upY)) {
                     auto result = check(targetObject, blocks, x, upY, From::None);
                     if (result != MoveResults::No) {
                         return result;

--- a/src/finder/concurrent_perfect_clear.hpp
+++ b/src/finder/concurrent_perfect_clear.hpp
@@ -9,7 +9,7 @@
 
 namespace finder {
     // Entry point to find best perfect clear
-    template<bool Allow180 = false, class M = core::srs::MoveGenerator<Allow180>>
+    template<bool Allow180 = false, bool AllowSoftdropTap = true, class M = core::srs::MoveGenerator<Allow180, AllowSoftdropTap>>
     class ConcurrentPerfectClearFinder {
     public:
         ConcurrentPerfectClearFinder<M>(const core::Factory &factory, ThreadPool &threadPool)
@@ -25,7 +25,7 @@ namespace finder {
         ) {
             if (maxDepth == 1) {
                 auto moveGenerator = M(factory_);
-                auto finder = PerfectClearFinder<Allow180, M>(factory_, moveGenerator);
+                auto finder = PerfectClearFinder<Allow180, AllowSoftdropTap, M>(factory_, moveGenerator);
                 return finder.run(
                         field, pieces, maxDepth, maxLine, holdEmpty, leastLineClears, initCombo, initB2b,
                         searchTypes, alwaysRegularAttack, lastHoldPriority, fastSearchStartDepth
@@ -117,7 +117,7 @@ namespace finder {
 
                             auto moveGenerator = M(factory_);
                             auto reachable = core::srs_rotate_end::Reachable(factory_);
-                            auto finder = PCFindRunner<Allow180, M, Candidate, Record>(
+                            auto finder = PCFindRunner<Allow180, AllowSoftdropTap, M, Candidate, Record>(
                                     factory_, moveGenerator, reachable, runnerStatus_
                             );
 
@@ -236,8 +236,9 @@ namespace finder {
 
                             auto moveGenerator = M(factory_);
                             auto reachable = core::srs_rotate_end::Reachable(factory_);
-                            auto finder = PCFindRunner<Allow180, M, Candidate, Record>(factory_, moveGenerator, reachable,
-                                                                             runnerStatus_);
+                            auto finder = PCFindRunner<Allow180, AllowSoftdropTap, M>(
+                                factory_, moveGenerator, reachable, runnerStatus_
+                            );
                             Record record;
                             {
                                 std::lock_guard<std::mutex> guard(mutex);
@@ -350,7 +351,7 @@ namespace finder {
 
                             auto moveGenerator = M(factory_);
                             auto reachable = core::srs_rotate_end::Reachable(factory_);
-                            auto finder = PCFindRunner<Allow180, M, Candidate, Record>(
+                            auto finder = PCFindRunner<Allow180, AllowSoftdropTap, M, Candidate, Record>(
                                     factory_, moveGenerator, reachable, runnerStatus_
                             );
 
@@ -517,12 +518,12 @@ namespace finder {
                 const core::Field &field,
                 const C &candidate,
                 M &moveGenerator,
-                core::srs_rotate_end::Reachable<> &reachable,
+                core::srs_rotate_end::Reachable<Allow180, AllowSoftdropTap> &reachable,
                 std::vector<core::Move> &moves,
                 const std::vector<core::PieceType> &pieces,
                 std::vector<PreOperation<C>> &output
         ) const {
-            auto mover = Mover<Allow180, M, C>(factory_, moveGenerator, reachable);
+            auto mover = Mover<Allow180, AllowSoftdropTap, M, C>(factory_, moveGenerator, reachable);
 
             int pieceSize = pieces.size();
 
@@ -585,7 +586,7 @@ namespace finder {
         const core::Factory &factory_;
         ThreadPool &threadPool_;
         M moveGenerator_;
-        core::srs_rotate_end::Reachable<> reachable_;
+        core::srs_rotate_end::Reachable<Allow180, AllowSoftdropTap> reachable_;
         RunnerStatus runnerStatus_{};
     };
 }

--- a/src/finder/concurrent_perfect_clear.hpp
+++ b/src/finder/concurrent_perfect_clear.hpp
@@ -12,9 +12,9 @@ namespace finder {
     template<bool Allow180 = false, bool AllowSoftdropTap = true, class M = core::srs::MoveGenerator<Allow180, AllowSoftdropTap>>
     class ConcurrentPerfectClearFinder {
     public:
-        ConcurrentPerfectClearFinder<M>(const core::Factory &factory, ThreadPool &threadPool)
+        ConcurrentPerfectClearFinder(const core::Factory &factory, ThreadPool &threadPool)
                 : factory_(factory), threadPool_(threadPool),
-                  moveGenerator_(M(factory)), reachable_(core::srs_rotate_end::Reachable(factory)) {
+                  moveGenerator_(M(factory)), reachable_(core::srs_rotate_end::Reachable<Allow180, AllowSoftdropTap>(factory)) {
         }
 
         // If `alwaysRegularAttack` is true, mini spin is judged as regular attack
@@ -116,7 +116,7 @@ namespace finder {
                             };
 
                             auto moveGenerator = M(factory_);
-                            auto reachable = core::srs_rotate_end::Reachable(factory_);
+                            auto reachable = core::srs_rotate_end::Reachable<Allow180, AllowSoftdropTap>(factory_);
                             auto finder = PCFindRunner<Allow180, AllowSoftdropTap, M, Candidate, Record>(
                                     factory_, moveGenerator, reachable, runnerStatus_
                             );
@@ -235,7 +235,7 @@ namespace finder {
                             };
 
                             auto moveGenerator = M(factory_);
-                            auto reachable = core::srs_rotate_end::Reachable(factory_);
+                            auto reachable = core::srs_rotate_end::Reachable<Allow180, AllowSoftdropTap>(factory_);
                             auto finder = PCFindRunner<Allow180, AllowSoftdropTap, M>(
                                 factory_, moveGenerator, reachable, runnerStatus_
                             );
@@ -350,7 +350,7 @@ namespace finder {
                             };
 
                             auto moveGenerator = M(factory_);
-                            auto reachable = core::srs_rotate_end::Reachable(factory_);
+                            auto reachable = core::srs_rotate_end::Reachable<Allow180, AllowSoftdropTap>(factory_);
                             auto finder = PCFindRunner<Allow180, AllowSoftdropTap, M, Candidate, Record>(
                                     factory_, moveGenerator, reachable, runnerStatus_
                             );

--- a/src/finder/spins.hpp
+++ b/src/finder/spins.hpp
@@ -54,9 +54,10 @@ namespace finder {
     }
 
     //  Caution: mini attack is 0
-    template<bool Allow180>
+    template<bool Allow180, bool AllowSoftdropTap>
     constexpr int getAttackIfTSpin(
-            core::srs::MoveGenerator<Allow180> &moveGenerator, core::srs_rotate_end::Reachable<Allow180> &reachable,
+            core::srs::MoveGenerator<Allow180, AllowSoftdropTap> &moveGenerator,
+            core::srs_rotate_end::Reachable<Allow180, AllowSoftdropTap> &reachable,
             const core::Factory &factory, const core::Field &field,
             core::PieceType pieceType, const core::Move &move, int numCleared, bool b2b
     ) {
@@ -166,9 +167,10 @@ namespace finder {
         return b2b ? 1 : 0;
     }
 
-    template<bool AlwaysRegularAttack, bool Allow180>
-    inline int getAttackIfAllSpins(
-            core::srs::MoveGenerator<Allow180> &moveGenerator, core::srs_rotate_end::Reachable<Allow180> &reachable,
+    template<bool AlwaysRegularAttack, bool Allow180, bool AllowSoftdropTap>
+    constexpr int getAttackIfAllSpins(
+            core::srs::MoveGenerator<Allow180, AllowSoftdropTap> &moveGenerator,
+            core::srs_rotate_end::Reachable<Allow180, AllowSoftdropTap> &reachable,
             const core::Factory &factory, const core::Field &field,
             core::PieceType pieceType, const core::Move &move, int numCleared, bool b2b
     ) {

--- a/test/core/test_moves.cpp
+++ b/test/core/test_moves.cpp
@@ -255,6 +255,21 @@ namespace core {
                 EXPECT_TRUE(assertMove(moves, Move{RotateType::Reverse, 4, 3, true}));
                 EXPECT_TRUE(assertMove(moves, Move{RotateType::Reverse, 5, 2, false}));
             }
+            {
+                constexpr bool Allow180 = false;
+                constexpr bool AllowSoftdropTap = false;
+                auto generator = MoveGenerator<Allow180, AllowSoftdropTap>(factory);
+
+                auto moves = std::vector<Move>();
+                generator.search(moves, field, PieceType::J, 4);
+
+                EXPECT_EQ(moves.size(), 3);
+                EXPECT_FALSE(assertMove(moves, Move{RotateType::Spawn, 5, 2, false}));
+                EXPECT_TRUE(assertMove(moves, Move{RotateType::Right, 4, 1, true}));
+                EXPECT_TRUE(assertMove(moves, Move{RotateType::Reverse, 3, 3, true}));
+                EXPECT_TRUE(assertMove(moves, Move{RotateType::Reverse, 4, 3, true}));
+                EXPECT_FALSE(assertMove(moves, Move{RotateType::Reverse, 5, 2, false}));
+            }
         }
     }
 
@@ -385,6 +400,47 @@ namespace core {
 
                 EXPECT_TRUE(reachable.checks(field, PieceType::T, RotateType::Right, 1, 1, 24));
                 EXPECT_TRUE(reachable.checks(field, PieceType::T, RotateType::Left, 1, 2, 24));
+            }
+        }
+
+        TEST_F(SRSRotateEndReachableTest, case3) {
+            auto factory = Factory::create();
+
+            {
+                // constexpr bool Allow180 = false;
+                // constexpr bool AllowSoftdropTap = true;
+                auto reachable = Reachable(factory);
+
+                auto field = createField(
+                        "XXXX_XXXXX"s +
+                        "XXXX_XXXXX"s +
+                        "XX____XXXX"s +
+                        "XXXX_XXXXX"s +
+                        "XXXX_XXXXX"s +
+                        "XXXX_XXXXX"s +
+                        ""
+                );
+
+                EXPECT_TRUE(reachable.checks(field, PieceType::I, RotateType::Spawn, 3, 3, 24));
+                EXPECT_TRUE(reachable.checks(field, PieceType::I, RotateType::Reverse, 4, 3, 24));
+            }
+            {
+                constexpr bool Allow180 = false;
+                constexpr bool AllowSoftdropTap = false;
+                auto reachable = Reachable<Allow180, AllowSoftdropTap>(factory);
+
+                auto field = createField(
+                        "XXXX_XXXXX"s +
+                        "XXXX_XXXXX"s +
+                        "XX____XXXX"s +
+                        "XXXX_XXXXX"s +
+                        "XXXX_XXXXX"s +
+                        "XXXX_XXXXX"s +
+                        ""
+                );
+
+                EXPECT_FALSE(reachable.checks(field, PieceType::I, RotateType::Spawn, 3, 3, 24));
+                EXPECT_FALSE(reachable.checks(field, PieceType::I, RotateType::Reverse, 4, 3, 24));
             }
         }
     }

--- a/test/core/test_moves.cpp
+++ b/test/core/test_moves.cpp
@@ -271,6 +271,38 @@ namespace core {
                 EXPECT_FALSE(assertMove(moves, Move{RotateType::Reverse, 5, 2, false}));
             }
         }
+
+        TEST_F(SRSMoveGeneratorTest, case9) {
+            auto field = createField(
+                    "__XXXXXXXX"s +
+                    "________XX"s +
+                    "________XX"s +
+                    "XXXXXX____"s +
+                    "XXXXXX____"s +
+                    ""
+            );
+
+            auto factory = Factory::create();
+
+            {
+                auto generator = MoveGenerator(factory);
+
+                auto moves = std::vector<Move>();
+                generator.search(moves, field, PieceType::T, 5);
+
+                EXPECT_EQ(moves.size(), 23);
+            }
+            {
+                constexpr bool Allow180 = false;
+                constexpr bool AllowSoftdropTap = false;
+                auto generator = MoveGenerator<Allow180, AllowSoftdropTap>(factory);
+
+                auto moves = std::vector<Move>();
+                generator.search(moves, field, PieceType::T, 5);
+
+                EXPECT_EQ(moves.size(), 23);
+            }
+        }
     }
 
     namespace srs_rotate_end {

--- a/test/finder/test_concurrent_perfect_clear.cpp
+++ b/test/finder/test_concurrent_perfect_clear.cpp
@@ -337,6 +337,43 @@ namespace finder {
         }
     }
 
+    TEST_F(ConcurrentPerfectClearTest, case7_srsplus_r180) {
+        auto factory = core::Factory::createForSSRPlus();
+        auto threadPool = ThreadPool(4);
+
+        auto field = core::createField(
+                "XXX___XXXX"s +
+                "X_XX__XXXX"s +
+                "__XX__XXXX"s +
+                "X_____XXXX"s +
+                "X_____XXXX"s +
+                ""
+        );
+        auto maxLine = 5;
+
+        {
+            // constexpr bool Allow180 = false;
+            auto finder = ConcurrentPerfectClearFinder(factory, threadPool);
+            auto pieces = std::vector{
+                core::PieceType::T, core::PieceType::T, core::PieceType::T, core::PieceType::T,
+                core::PieceType::T,
+            };
+            auto result = finder.run(field, pieces, maxLine, true);
+            EXPECT_FALSE(!result.empty());
+        }
+        {
+            constexpr bool Allow180 = true;
+            auto moveGenerator = core::srs::MoveGenerator<Allow180>(factory);
+            auto finder = PerfectClearFinder<Allow180>(factory, moveGenerator);
+            auto pieces = std::vector{
+                core::PieceType::T, core::PieceType::T, core::PieceType::T, core::PieceType::T,
+                core::PieceType::T,
+            };
+            auto result = finder.run(field, pieces, maxLine, true);
+            EXPECT_TRUE(!result.empty());
+        }
+    }
+
     // Equivalent to PerfectClearTest::case8
     TEST_F(ConcurrentPerfectClearTest, case8) {
         auto factory = core::Factory::create();
@@ -411,6 +448,42 @@ namespace finder {
                 EXPECT_EQ(result[index].x, expected[index].x);
                 EXPECT_EQ(result[index].y, expected[index].y);
             }
+        }
+    }
+
+    TEST_F(ConcurrentPerfectClearTest, case9) {
+        auto factory = core::Factory::createForSSRPlus();
+        auto threadPool = ThreadPool(4);
+
+        auto field = core::createField(
+                "XXXX_XXX__"s +
+                "XX____XX__"s +
+                "XXXX_XXXXX"s +
+                "XXXX_XXXXX"s +
+                "XXXX_XXXXX"s +
+                ""
+        );
+        auto maxLine = 5;
+
+        {
+            // constexpr bool Allow180 = false;
+            // constexpr bool AllowSoftdropTap = true;
+            auto finder = ConcurrentPerfectClearFinder(factory, threadPool);
+            auto pieces = std::vector{
+                core::PieceType::O, core::PieceType::I, core::PieceType::I,
+            };
+            auto result = finder.run(field, pieces, maxLine, false);
+            EXPECT_TRUE(!result.empty());
+        }
+        {
+            constexpr bool Allow180 = false;
+            constexpr bool AllowSoftdropTap = false;
+            auto finder = ConcurrentPerfectClearFinder<Allow180, AllowSoftdropTap>(factory, threadPool);
+            auto pieces = std::vector{
+                core::PieceType::O, core::PieceType::I, core::PieceType::I,
+            };
+            auto result = finder.run(field, pieces, maxLine, false);
+            EXPECT_FALSE(!result.empty());
         }
     }
 

--- a/test/finder/test_perfect_clear.cpp
+++ b/test/finder/test_perfect_clear.cpp
@@ -373,6 +373,43 @@ namespace finder {
         }
     }
 
+    TEST_F(PerfectClearTest, case9) {
+        auto factory = core::Factory::create();
+
+        auto field = core::createField(
+                "XXXX_XXXXX"s +
+                "XX____XXXX"s +
+                "XXXX_XXXXX"s +
+                "XXXX_XXXXX"s +
+                "XXXX_XXXXX"s +
+                ""
+        );
+        auto maxLine = 5;
+
+        {
+            // constexpr bool Allow180 = false;
+            // constexpr bool AllowSoftdropTap = true;
+            auto moveGenerator = core::srs::MoveGenerator(factory);
+            auto finder = PerfectClearFinder(factory, moveGenerator);
+            auto pieces = std::vector{
+                core::PieceType::O, core::PieceType::I, core::PieceType::I,
+            };
+            auto result = finder.run(field, pieces, maxLine, false);
+            EXPECT_TRUE(!result.empty());
+        }
+        {
+            constexpr bool Allow180 = false;
+            constexpr bool AllowSoftdropTap = false;
+            auto moveGenerator = core::srs::MoveGenerator<Allow180, AllowSoftdropTap>(factory);
+            auto finder = PerfectClearFinder<Allow180, AllowSoftdropTap>(factory, moveGenerator);
+            auto pieces = std::vector{
+                core::PieceType::O, core::PieceType::I, core::PieceType::I,
+            };
+            auto result = finder.run(field, pieces, maxLine, false);
+            EXPECT_FALSE(!result.empty());
+        }
+    }
+
     TEST_F(PerfectClearTest, longtest1) {
         auto factory = core::Factory::create();
         auto moveGenerator = core::srs::MoveGenerator(factory);


### PR DESCRIPTION
If AllowSoftdropTap is false, the softdrop is guaranteed to continue to the ground.

### Usage

```cpp
// PerfectClearFinder
auto factory = core::Factory::createForSSRPlus();
constexpr bool Allow180 = true;
constexpr bool AllowSoftdropTap = false;
auto moveGenerator = core::srs::MoveGenerator<Allow180>(factory);
auto finder = finder::PerfectClearFinder<Allow180, AllowSoftdropTap>(factory, moveGenerator);

// ConcurrentPerfectClearFinder
auto factory = core::Factory::createForSSRPlus();
auto threadPool = finder::ThreadPool(4);
constexpr bool Allow180 = true;
constexpr bool AllowSoftdropTap = false;
auto finder = finder::ConcurrentPerfectClearFinder<Allow180, AllowSoftdropTap>(factory, threadPool);
```